### PR TITLE
Add Python diagram script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,20 @@
 
 ## Как начать
 
-1. Установите зависимости для генерации диаграмм:
+1. Установите зависимости для генерации диаграмм. На Linux используйте:
    ```bash
    sudo apt-get update && sudo apt-get install -y plantuml
    npm install -g @mermaid-js/mermaid-cli
    ```
+   На macOS те же инструменты можно установить через Homebrew:
+   ```bash
+   brew install plantuml node
+   npm install -g @mermaid-js/mermaid-cli
+   ```
 2. Поместите диаграммы в каталог `docs/diagrams`.
-3. Запустите `scripts/render_diagrams.sh`, чтобы сгенерировать изображения в `docs/generated`.
-   Каталог `docs/generated` добавлен в `.gitignore`, поэтому готовые картинки не
-   хранятся в репозитории.
-   Скрипт использует `scripts/puppeteer.json` для запуска `mmdc` без sandbox,
+3. Сгенерируйте изображения одним из скриптов:
+   - `scripts/render_diagrams.sh` – bash-версия.
+   - `scripts/render_diagrams.py` – кроссплатформенная альтернатива на Python.
+   Файлы появятся в каталоге `docs/generated`, который исключён из репозитория.
+   Скрипты используют `scripts/puppeteer.json` для запуска `mmdc` без sandbox,
    что упрощает работу в root-окружениях.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # Документация
 
 В каталоге `diagrams` находятся примеры диаграмм PlantUML и Mermaid.
-Для генерации изображений выполните скрипт `scripts/render_diagrams.sh`.
+Для генерации изображений используйте один из скриптов:
+- `scripts/render_diagrams.sh` – bash-версия.
+- `scripts/render_diagrams.py` – аналог на Python.
 Полученные файлы появятся в каталоге `generated`, который исключён из репозитория.

--- a/scripts/render_diagrams.py
+++ b/scripts/render_diagrams.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Render PlantUML and Mermaid diagrams.
+
+This script recursively scans the given input directory for ``.puml`` and
+``.mmd`` files and renders them as PNG images. PlantUML diagrams are
+processed with the ``plantuml`` command, while Mermaid diagrams are
+rendered using ``mmdc``.
+
+Usage:
+    python render_diagrams.py [input_dir] [output_dir]
+
+If paths are not provided, ``docs/diagrams`` is used as the input
+and ``docs/generated`` as the output directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+
+def run_command(cmd: list[str]) -> None:
+    """Run a command and raise ``RuntimeError`` if it fails."""
+    try:
+        subprocess.run(cmd, check=True)
+    except (OSError, subprocess.CalledProcessError) as exc:
+        raise RuntimeError(f"Command failed: {' '.join(cmd)}") from exc
+
+
+def render_plantuml(files: list[Path], output_dir: Path) -> None:
+    for file in files:
+        run_command(
+            [
+                "plantuml",
+                "-tpng",
+                str(file),
+                "-o",
+                str(output_dir.resolve()),
+            ]
+        )
+
+
+def render_mermaid(files: list[Path], output_dir: Path) -> None:
+    config = Path(__file__).with_name("puppeteer.json")
+    for file in files:
+        output_file = output_dir / f"{file.stem}.png"
+        run_command(
+            [
+                "mmdc",
+                "-i",
+                str(file),
+                "-o",
+                str(output_file),
+                "--puppeteerConfigFile",
+                str(config),
+            ]
+        )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Render diagrams")
+    parser.add_argument(
+        "input_dir",
+        nargs="?",
+        default="docs/diagrams",
+        help="Directory with source diagrams",
+    )
+    parser.add_argument(
+        "output_dir",
+        nargs="?",
+        default="docs/generated",
+        help="Where to place generated PNG files",
+    )
+
+    args = parser.parse_args()
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    plantuml_files = list(input_dir.rglob("*.puml"))
+    mermaid_files = list(input_dir.rglob("*.mmd"))
+
+    if plantuml_files:
+        render_plantuml(plantuml_files, output_dir)
+    if mermaid_files:
+        render_mermaid(mermaid_files, output_dir)
+
+    print(f"Diagrams generated in {output_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `scripts/render_diagrams.py` for diagram generation via Python
- document macOS setup and Python script usage
- update docs to mention the Python script

## Testing
- `./scripts/render_diagrams.py`


------
https://chatgpt.com/codex/tasks/task_e_6862faadc6f8832f86a638884bf75764